### PR TITLE
fix problems with current version of CascadeSelect

### DIFF
--- a/src/UDFCheck/UDFCheckFormGUI.php
+++ b/src/UDFCheck/UDFCheckFormGUI.php
@@ -157,6 +157,9 @@ class UDFCheckFormGUI extends ilPropertyFormGUI {
 							$check_radio->addOption($check_radio_text);
 
 							foreach ($select_gui->getColumnDefinition() as $key => $name) {
+								if (is_array($name)) {
+									$name=$name["name"]." ( ".$name["default"]." ) ";
+								}
 								$text_gui = new ilTextInputGUI($name, self::F_CHECK_VALUE_MUL . $key);
 								$check_radio_text->addSubItem($text_gui);
 							}


### PR DESCRIPTION
This fix adresses the changes in CascsdeSelect since versien 6-new festures and 7. CascadeSelect returns now an array with the keya "name" and "default" instead of a string. This causes a crash when html for the edit form of an udf-check is created (somewhere down the line htmlspecialchars ist called with an array as parameter).
the fix shoud not create conflicts with the older versions of CascadeSelect, since it only acts if an array si given for the column definition. 
Tested with ILIAS 7, current CascadeSeect and current UserDefaults 
