### PR TITLE
Add null check for AssignedOrguPosition before assigning.

### DIFF
--- a/src/UserSetting/UserSetting.php
+++ b/src/UserSetting/UserSetting.php
@@ -1552,7 +1552,9 @@ class UserSetting extends ActiveRecord {
 				continue;
 			}
 			$orgUnit = new ilObjOrgUnit($orgu_ref_id, true);
-			ilOrgUnitUserAssignment::findOrCreateAssignment($usr_id, (int)$this->getAssignedOrguPosition(), $orgUnit->getRefId());
+			if (!is_null($this->getAssignedOrguPosition())) {
+			        ilOrgUnitUserAssignment::findOrCreateAssignment($usr_id, (int)$this->getAssignedOrguPosition(), $orgUnit->getRefId());
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Add a null check of the AssignedOrguPosition before calling the findOrCreateAssignment function to prevent the creation of erroneous entries to "il_orgu_ua" with position_id = 0 when AssignedOrguPosition is null.

This fix was created for a ILIAS 7 Installation that experienced a bug where UserDefaults created entries in the User-Org-Assignment table (il_orgu_ua) with position_id = 0, which does not exist. The reason for position 0 is the typecast in line 1555 to int, where null was typecast to 0 and inserted.